### PR TITLE
Fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+0.8.1.1
+-------
+
+- Fix tests compiling with servant-0.9

--- a/servant-mock.cabal
+++ b/servant-mock.cabal
@@ -1,5 +1,5 @@
 name:                servant-mock
-version:             0.8.1
+version:             0.8.1.1
 x-revision:          1
 synopsis:            Derive a mock server for free from your servant API types
 description:
@@ -14,7 +14,7 @@ maintainer:          haskell-servant-maintainers@googlegroups.com
 copyright:           2015-2016 Servant Contributors
 category:            Web
 build-type:          Simple
-extra-source-files:  include/*.h
+extra-source-files:  README.md CHANGELOG.md include/*.h
 cabal-version:       >=1.10
 bug-reports:         http://github.com/haskell-servant/servant-mock/issues
 


### PR DESCRIPTION
Resolve #3 

``` diff
--- servant-mock-0.8.1/servant-mock.cabal   2016-09-29 11:39:34.000000000 +0300
+++ servant-mock/servant-mock.cabal 2016-09-25 19:11:01.000000000 +0300
@@ -25,6 +25,7 @@
 flag example
   description: Build the example too
   default: True
+  manual: True

 library
   exposed-modules:
diff -ur servant-mock-0.8.1/src/Servant/Mock.hs servant-mock/src/Servant/Mock.hs
--- servant-mock-0.8.1/src/Servant/Mock.hs  2016-08-22 17:16:42.000000000 +0300
+++ servant-mock/src/Servant/Mock.hs    2016-09-25 19:11:01.000000000 +0300
@@ -115,8 +115,10 @@
 instance (KnownSymbol s, FromHttpApiData a, HasMock rest context) => HasMock (Capture s a :> rest) context where
   mock _ context = \_ -> mock (Proxy :: Proxy rest) context

+#if MIN_VERSION_servant(0,8,1)
 instance (KnownSymbol s, FromHttpApiData a, HasMock rest context) => HasMock (CaptureAll s a :> rest) context where
   mock _ context = \_ -> mock (Proxy :: Proxy rest) context
+#endif

 instance (AllCTUnrender ctypes a, HasMock rest context) => HasMock (ReqBody ctypes a :> rest) context where
   mock _ context = \_ -> mock (Proxy :: Proxy rest) context
Only in servant-mock: stack-servant-0.8.1.yaml
Only in servant-mock: stack-servant-0.8.yaml
diff -ur servant-mock-0.8.1/test/Servant/MockSpec.hs servant-mock/test/Servant/MockSpec.hs
--- servant-mock-0.8.1/test/Servant/MockSpec.hs 2016-08-22 17:16:42.000000000 +0300
+++ servant-mock/test/Servant/MockSpec.hs   2016-09-25 19:11:01.000000000 +0300
@@ -8,9 +8,7 @@
 module Servant.MockSpec where

 import           Data.Aeson as Aeson
-import           Data.ByteString.Conversion.To
 import           Data.Proxy
-import           Data.String
 import           GHC.Generics
 import           Network.Wai
 import           Servant.API
@@ -22,6 +20,9 @@
 import           Servant.API.Internal.Test.ComprehensiveAPI
 import           Servant.Mock

+import Data.ByteString.Conversion.To
+import Data.String
+
 -- This declaration simply checks that all instances are in place.
 _ = mock comprehensiveAPI (Proxy :: Proxy '[NamedContext "foo" '[]])

@@ -40,9 +41,16 @@
   | ArbitraryHeader
   deriving (Show)

+-- Needed for servant-0.8.1
 instance ToByteString TestHeader where
   builder = fromString . show

+instance ToHttpApiData TestHeader where
+  toHeader = toHeader . show
+  toUrlPiece = toUrlPiece . show
+  toQueryParam = toQueryParam . show
+
+
 instance Arbitrary TestHeader where
   arbitrary = return ArbitraryHeader
```
