### PR TITLE
Add supports for ghc-8.10.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,20 +32,101 @@ before_cache:
   - rm -rfv $CABALHOME/packages/head.hackage
 jobs:
   include:
+    - compiler: ghc-8.10.4
+      addons:
+        {
+          "apt":
+            {
+              "sources":
+                [
+                  {
+                    "sourceline": "deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main",
+                    "key_url": "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286",
+                  },
+                ],
+              "packages": ["ghc-8.10.4", "cabal-install-3.0"],
+            },
+        }
+      os: linux
     - compiler: ghc-8.8.1
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.8.1","cabal-install-3.0"]}}
+      addons:
+        {
+          "apt":
+            {
+              "sources":
+                [
+                  {
+                    "sourceline": "deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main",
+                    "key_url": "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286",
+                  },
+                ],
+              "packages": ["ghc-8.8.1", "cabal-install-3.0"],
+            },
+        }
       os: linux
     - compiler: ghc-8.6.5
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.6.5","cabal-install-3.0"]}}
+      addons:
+        {
+          "apt":
+            {
+              "sources":
+                [
+                  {
+                    "sourceline": "deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main",
+                    "key_url": "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286",
+                  },
+                ],
+              "packages": ["ghc-8.6.5", "cabal-install-3.0"],
+            },
+        }
       os: linux
     - compiler: ghc-8.4.4
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.4.4","cabal-install-3.0"]}}
+      addons:
+        {
+          "apt":
+            {
+              "sources":
+                [
+                  {
+                    "sourceline": "deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main",
+                    "key_url": "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286",
+                  },
+                ],
+              "packages": ["ghc-8.4.4", "cabal-install-3.0"],
+            },
+        }
       os: linux
     - compiler: ghc-8.2.2
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.2.2","cabal-install-3.0"]}}
+      addons:
+        {
+          "apt":
+            {
+              "sources":
+                [
+                  {
+                    "sourceline": "deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main",
+                    "key_url": "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286",
+                  },
+                ],
+              "packages": ["ghc-8.2.2", "cabal-install-3.0"],
+            },
+        }
       os: linux
     - compiler: ghc-8.0.2
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.0.2","cabal-install-3.0"]}}
+      addons:
+        {
+          "apt":
+            {
+              "sources":
+                [
+                  {
+                    "sourceline": "deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main",
+                    "key_url": "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286",
+                  },
+                ],
+              "packages": ["ghc-8.0.2", "cabal-install-3.0"],
+            },
+        }
       os: linux
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')
@@ -139,6 +220,5 @@ script:
   # Building without installed constraints for packages in global-db...
   - rm -f cabal.project.local
   - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks all
-
 # REGENDATA ("0.9.20200121",["--branches","master","-o",".travis.yml","servant-mock.cabal"])
 # EOF

--- a/servant-mock.cabal
+++ b/servant-mock.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                servant-mock
-version:             0.8.7
+version:             0.9.7
 
 synopsis:            Derive a mock server for free from your servant API types
 category:            Servant, Web, Testing
@@ -23,6 +23,7 @@ tested-with:
    || ==8.4.4
    || ==8.6.5
    || ==8.8.1
+   || ==8.10.4
 
 extra-source-files:  README.md CHANGELOG.md include/*.h
 
@@ -39,14 +40,14 @@ library
   exposed-modules:
     Servant.Mock
   build-depends:
-    base            >=4.9      && <4.14,
+    base            >=4.9      && <4.15,
     base-compat     >=0.10.5   && <0.12,
     bytestring      >=0.10.8.1 && <0.11,
     http-types      >=0.12.2   && <0.13,
     servant         >=0.17     && <0.19,
     servant-server  >=0.17     && <0.19,
     transformers    >=0.5.2.0  && <0.6,
-    QuickCheck      >=2.12.6.1 && <2.14,
+    QuickCheck      >=2.12.6.1 && <2.14.3,
     wai             >=3.2.1.2  && <3.3
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Servant/Mock.hs
+++ b/src/Servant/Mock.hs
@@ -198,9 +198,9 @@ instance
     HasContextEntry (context .++ DefaultErrorFormatters) ErrorFormatters =>
 #endif
     HasMock Raw context where
-  mock _ _ = Tagged $ \_req respond -> do
+  mock _ _ = Tagged $ \_req _respond -> do
     bdy <- genBody
-    respond $ responseLBS status200 [] bdy
+    _respond $ responseLBS status200 [] bdy
 
     where genBody = pack <$> generate (vector 100 :: Gen [Char])
 
@@ -215,6 +215,9 @@ instance HasMock api context => HasMock (Summary d :> api) context where
     mock _ context = mock (Proxy :: Proxy api) context
 
 instance HasMock api context => HasMock (Description d :> api) context where
+    mock _ context = mock (Proxy :: Proxy api) context
+
+instance (AtLeastOneFragment api, FragmentUnique (Fragment d :> api), HasMock api context) => HasMock (Fragment d :> api) context where
     mock _ context = mock (Proxy :: Proxy api) context
 
 instance ( HasContextEntry context (NamedContext name subContext)


### PR DESCRIPTION
Add supports in GHC-8.10.4

- adds 8.10.4 in travis build process
- relax quickcheck version to 2.14.2
- fix shadow variable binding warning
- add `HasMock` instance for Fragment modifier

@fisx @phadej ^