### PR TITLE
Support servant-server-0.19.1

### DIFF
--- a/servant-mock.cabal
+++ b/servant-mock.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                servant-mock
-version:             0.8.7
+version:             0.8.8
 
 synopsis:            Derive a mock server for free from your servant API types
 category:            Servant, Web, Testing
@@ -43,8 +43,8 @@ library
     base-compat     >=0.10.5   && <0.12,
     bytestring      >=0.10.8.1 && <0.11,
     http-types      >=0.12.2   && <0.13,
-    servant         >=0.17     && <0.19,
-    servant-server  >=0.17     && <0.19,
+    servant         >=0.17     && <0.20,
+    servant-server  >=0.17     && <0.20,
     transformers    >=0.5.2.0  && <0.6,
     QuickCheck      >=2.12.6.1 && <2.14,
     wai             >=3.2.1.2  && <3.3

--- a/src/Servant/Mock.hs
+++ b/src/Servant/Mock.hs
@@ -63,6 +63,7 @@ import Prelude.Compat
 import           Control.Monad.IO.Class
 import           Data.ByteString.Lazy.Char8 (pack)
 import           Data.Proxy
+import           Data.Typeable (Typeable)
 import           GHC.TypeLits
 import           Network.HTTP.Types.Status
 import           Network.Wai
@@ -118,10 +119,10 @@ instance (HasMock a context, HasMock b context) => HasMock (a :<|> b) context wh
 instance (KnownSymbol path, HasMock rest context) => HasMock (path :> rest) context where
   mock _ = mock (Proxy :: Proxy rest)
 
-instance (KnownSymbol s, FromHttpApiData a, HasMock rest context, SBoolI (FoldLenient mods)) => HasMock (Capture' mods s a :> rest) context where
+instance (KnownSymbol s, FromHttpApiData a, Typeable a, HasMock rest context, SBoolI (FoldLenient mods)) => HasMock (Capture' mods s a :> rest) context where
   mock _ context = \_ -> mock (Proxy :: Proxy rest) context
 
-instance (KnownSymbol s, FromHttpApiData a, HasMock rest context) => HasMock (CaptureAll s a :> rest) context where
+instance (KnownSymbol s, FromHttpApiData a, Typeable a, HasMock rest context) => HasMock (CaptureAll s a :> rest) context where
   mock _ context = \_ -> mock (Proxy :: Proxy rest) context
 
 instance (AllCTUnrender ctypes a, HasMock rest context, SBoolI (FoldLenient mods))
@@ -225,6 +226,13 @@ instance ( HasContextEntry context (NamedContext name subContext)
   HasMock (WithNamedContext name subContext rest) context where
 
   mock _ _ = mock (Proxy :: Proxy rest) (Proxy :: Proxy subContext)
+
+instance ( HasMock api context
+         , AtLeastOneFragment api
+         , FragmentUnique (Fragment a :> api)
+         ) =>
+  HasMock (Fragment a :> api) context where
+  mock _ context = mock (Proxy :: Proxy api) context
 
 mockArbitrary :: (MonadIO m, Arbitrary a) => m a
 mockArbitrary = liftIO (generate arbitrary)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,6 @@
-resolver: nightly-2016-10-07
+resolver: lts-20.5
 packages:
 - '.'
-extra-deps:
-- hspec-wai-0.8.0
-- hspec-expectations-0.8.0
-- call-stack-0.1.0
-- hspec-2.3.1
-- hspec-discover-2.3.1
-- hspec-core-2.3.1
 flags: {}
 extra-package-dbs: []
+allow-newer: true


### PR DESCRIPTION
Since version 0.19.1, `servant-server` requires the type `a` in combinator `Capture foo a` to be `Typeable`. This commit adds the constraint in `HasMock` for `Capture'` and `CaptureAll`